### PR TITLE
stock_auto_move: externalize change group to be able to overload it

### DIFF
--- a/stock_auto_move/models/stock_auto_move.py
+++ b/stock_auto_move/models/stock_auto_move.py
@@ -25,11 +25,15 @@ class StockMove(models.Model):
         moves.action_done()
 
     @api.multi
-    def action_confirm(self):
+    def _change_procurement_group(self):
         automatic_group = self.env.ref('stock_auto_move.automatic_group')
         for move in self:
             if move.auto_move and move.group_id != automatic_group:
                 move.group_id = automatic_group
+
+    @api.multi
+    def action_confirm(self):
+        self._change_procurement_group()
         return super(StockMove, self).action_confirm()
 
 


### PR DESCRIPTION
In my use case, all products of the picking are in the same procurement group. And automatic move, is for a whole picking.
I don't want loss my original picking group. So I propose a hook, to be able to overload it in my project.
